### PR TITLE
Fix error propagation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,9 @@
 
 * Better printing of `rlang_error`s that happened in the subprocess.
 
+* The stacking of error objects is slightly different now, as we keep the
+  unmodified error from the subprocess in `$parent$error`.
+
 * callr now loads `.Rprofile` files from the current working directory
   by default. This works better with packrat, renv, and other software
   that relies on a local profile for initialization (#131).

--- a/R/eval.R
+++ b/R/eval.R
@@ -55,7 +55,7 @@
 #'   See details below.
 #' @param poll_connection Whether to have a control connection to
 #'   the process. This is used to transmit messages from the subprocess
-#'   to the parent.
+#'   to the main process.
 #' @param cmdargs Command line arguments to pass to the R process.
 #'   Note that `c("-f", rscript)` is appended to this, `rscript`
 #'   is the name of the script file to run. This contains a call to the
@@ -94,22 +94,26 @@
 #'
 #' `callr` handles errors properly. If the child process throws an
 #' error, then `callr` throws an error with the same error message
-#' in the parent process.
+#' in the main process.
 #'
 #' The `error` expert argument may be used to specify a different
 #' behavior on error. The following values are possible:
-#' * `error` is the default behavior: throw an error in the parent, with
-#'   the same error message. In fact the same error object is thrown again.
-#' * `stack` also throws an error in the parent, but the error
+#' * `error` is the default behavior: throw an error in the main process,
+#'   with a prefix and the same error message as in the subprocess.
+#' * `stack` also throws an error in the main process, but the error
 #'   is of a special kind, class `callr_error`, and it contains
 #'   both the original error object, and the call stack of the child,
-#'   as written out by [utils::dump.frames()].
+#'   as written out by [utils::dump.frames()]. This is now deprecated,
+#'   because the error thrown for `"error"` has the same information.
 #' * `debugger` is similar to `stack`, but in addition
 #'   to returning the complete call stack, it also start up a debugger
 #'   in the child call stack, via [utils::debugger()].
 #'
 #' The default error behavior can be also set using the `callr.error`
 #' option. This is useful to debug code that uses `callr`.
+#'
+#' callr uses parent errors, to keep the stacks of the main process and the
+#' subprocess(es) in the same error object. 
 #'
 #' @section Security considerations:
 #'

--- a/R/result.R
+++ b/R/result.R
@@ -66,14 +66,8 @@ get_result <- function(output, options) {
   if (remerr[[1]] == "error") {
     remerr[[2]]$message <- remerr[[2]]$message %||% "interrupt"
     msg <- conditionMessage(remerr[[2]]$error)
-    # We construct a new error object, that merges the trace of the
-    # subprocess to the current trace. But it uses the original error
-    # object otherwise, saved in remerr[[2]]$error.
     newerr <- new_callr_error(output, msg)
-    newerr$parent <- remerr[[2]]
-    newerr <- err$add_trace_back(newerr)
-    newerr$parent <- remerr[[2]]$error
-    throw(newerr)
+    throw(newerr, parent = remerr[[2]])
 
   } else if (remerr[[1]] == "stack") {
     myerr <- structure(

--- a/R/script.R
+++ b/R/script.R
@@ -70,9 +70,9 @@ make_vanilla_script_expr <- function(expr_file, res, error,
         data <- paste(e$code, msg, "\n")
         pxlib$write_fd(3L, data)
 
-        if (inherits(e, "cli_message") &&
-            !is.null(findRestart("cli_message_handled"))) {
-          invokeRestart("cli_message_handled")
+        if (inherits(e, "callr_message") &&
+            !is.null(findRestart("callr_message_handled"))) {
+          invokeRestart("callr_message_handled")
         } else if (inherits(e, "message") &&
                    !is.null(findRestart("muffleMessage"))) {
           invokeRestart("muffleMessage")

--- a/R/script.R
+++ b/R/script.R
@@ -18,7 +18,7 @@ make_vanilla_script_expr <- function(expr_file, res, error,
       rm("__callr_dump__", envir = .GlobalEnv)
 
       # callr_remote_error does have conditionMessage and conditionCall
-      # methods that defer to $error, but in the subprocess callr is not
+      # methods that refer to $error, but in the subprocess callr is not
       # loaded, maybe, and these methods are not defined. So we do add
       # the message and call of the original error
       e2 <- err$new_error(conditionMessage(e), call. = conditionCall(e))
@@ -37,6 +37,7 @@ make_vanilla_script_expr <- function(expr_file, res, error,
       if (!is.na(dcframe)) e2$`_ignore` <- list(c(1, dcframe + 1L))
       e2$`_pid` <- Sys.getpid()
       e2$`_timestamp` <- Sys.time()
+      if (inherits(e, "rlib_error")) e2$parent <- e$parent
       e2 <- err$add_trace_back(e2)
       saveRDS(list("error", e2), file = paste0(`__res__`, ".error")) },
       list(`__res__` = res)

--- a/man/r.Rd
+++ b/man/r.Rd
@@ -64,7 +64,7 @@ string \code{"2>&1"}, then standard error is redirected to standard output.}
 
 \item{poll_connection}{Whether to have a control connection to
 the process. This is used to transmit messages from the subprocess
-to the parent.}
+to the main process.}
 
 \item{error}{What to do if the remote process throws an error.
 See details below.}
@@ -137,17 +137,18 @@ The \code{r()} function from before 2.0.0 is called \code{\link[=r_copycat]{r_co
 
 \code{callr} handles errors properly. If the child process throws an
 error, then \code{callr} throws an error with the same error message
-in the parent process.
+in the main process.
 
 The \code{error} expert argument may be used to specify a different
 behavior on error. The following values are possible:
 \itemize{
-\item \code{error} is the default behavior: throw an error in the parent, with
-the same error message. In fact the same error object is thrown again.
-\item \code{stack} also throws an error in the parent, but the error
+\item \code{error} is the default behavior: throw an error in the main process,
+with a prefix and the same error message as in the subprocess.
+\item \code{stack} also throws an error in the main process, but the error
 is of a special kind, class \code{callr_error}, and it contains
 both the original error object, and the call stack of the child,
-as written out by \code{\link[utils:dump.frames]{utils::dump.frames()}}.
+as written out by \code{\link[utils:dump.frames]{utils::dump.frames()}}. This is now deprecated,
+because the error thrown for \code{"error"} has the same information.
 \item \code{debugger} is similar to \code{stack}, but in addition
 to returning the complete call stack, it also start up a debugger
 in the child call stack, via \code{\link[utils:debugger]{utils::debugger()}}.
@@ -155,6 +156,9 @@ in the child call stack, via \code{\link[utils:debugger]{utils::debugger()}}.
 
 The default error behavior can be also set using the \code{callr.error}
 option. This is useful to debug code that uses \code{callr}.
+
+callr uses parent errors, to keep the stacks of the main process and the
+subprocess(es) in the same error object.
 }
 
 \section{Security considerations}{

--- a/man/r_bg.Rd
+++ b/man/r_bg.Rd
@@ -54,7 +54,7 @@ string \code{"2>&1"}, then standard error is redirected to standard output.}
 
 \item{poll_connection}{Whether to have a control connection to
 the process. This is used to transmit messages from the subprocess
-to the parent.}
+to the main process.}
 
 \item{error}{What to do if the remote process throws an error.
 See details below.}

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -78,7 +78,8 @@ test_that("parent errors", {
     error = function(e) e)
 
   expect_s3_class(err, "rlib_error")
-  expect_s3_class(err$parent, "simpleError")
+  expect_s3_class(err$parent, "callr_remote_error")
+  expect_s3_class(err$parent$error, "simpleError")
   expect_match(
     conditionMessage(err),
     "callr subprocess failed: non-numeric argument")
@@ -98,7 +99,8 @@ test_that("parent errors, another level", {
 
   expect_s3_class(err, "rlib_error")
   expect_s3_class(err$parent, "rlib_error")
-  expect_s3_class(err$parent$parent, "simpleError")
+  expect_s3_class(err$parent$parent, "callr_remote_error")
+  expect_s3_class(err$parent$parent$error, "simpleError")
 
   expect_match(
     conditionMessage(err),
@@ -160,7 +162,8 @@ test_that("errors in r_bg() are merged", {
     error = function(e) e)
 
   expect_s3_class(err, "rlib_error")
-  expect_s3_class(err$parent, "simpleError")
+  expect_s3_class(err$parent, "callr_remote_error")
+  expect_s3_class(err$parent$error, "simpleError")
   expect_match(
     conditionMessage(err),
     "callr subprocess failed: non-numeric argument")
@@ -183,7 +186,8 @@ test_that("errors in r_process are merged", {
     error = function(e) e)
 
   expect_s3_class(err, "rlib_error")
-  expect_s3_class(err$parent, "simpleError")
+  expect_s3_class(err$parent, "callr_remote_error")
+  expect_s3_class(err$parent$error, "simpleError")
   expect_match(
     conditionMessage(err),
     "callr subprocess failed: non-numeric argument")
@@ -206,7 +210,8 @@ test_that("errors in r_session$run() are merged", {
 
   for (i in seq_along(err)) {
     expect_s3_class(err[[i]], "rlib_error")
-    expect_s3_class(err[[i]]$parent, "simpleError")
+    expect_s3_class(err[[i]]$parent, "callr_remote_error")
+    expect_s3_class(err[[i]]$parent$error, "simpleError")
     expect_match(
       conditionMessage(err[[i]]),
       "callr subprocess failed: non-numeric argument")
@@ -232,7 +237,8 @@ test_that("errors in r_session$call() are merged", {
 
   for (i in seq_along(err)) {
     expect_s3_class(err[[i]], "rlib_error")
-    expect_s3_class(err[[i]]$parent, "simpleError")
+    expect_s3_class(err[[i]]$parent, "callr_remote_error")
+    expect_s3_class(err[[i]]$parent$error, "simpleError")
     expect_match(
       conditionMessage(err[[i]]),
       "callr subprocess failed: non-numeric argument")
@@ -244,6 +250,9 @@ test_that("errors in r_session$call() are merged", {
 
 test_that("child error is not modified", {
   err <- tryCatch(callr::r(function() stop("foobar")), error = function(e) e)
-  expect_identical(class(err$parent), c("simpleError", "error", "condition"))
-  expect_null(err$parent$trace)
+  expect_identical(
+    class(err$parent$error),
+    c("simpleError", "error", "condition")
+  )
+  expect_null(err$parent$error$trace)
 })

--- a/tests/testthat/test-r-session.R
+++ b/tests/testthat/test-r-session.R
@@ -117,7 +117,7 @@ test_that("interrupt", {
   rs$poll_process(1000)
   res <- rs$read()
   expect_s3_class(res$error, "rlib_error")
-  expect_s3_class(res$error$parent, "interrupt")
+  expect_s3_class(res$error$parent$error, "interrupt")
   rs$close()
 })
 


### PR DESCRIPTION
Correctly stack errors, whether they are `rlib_error` or not.